### PR TITLE
bus: rename AccessBeyondPeripheral -> OutOfBounds

### DIFF
--- a/bus/mod.rs
+++ b/bus/mod.rs
@@ -9,7 +9,7 @@ use std::fmt;
 pub enum ErrorKind
 {
 	Unimplemented,
-	AccessBeyondPeripheral,
+	OutOfBounds,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Addressing discussion in #5 