### PR TITLE
bus: make address parameter generic

### DIFF
--- a/bus/mod.rs
+++ b/bus/mod.rs
@@ -45,8 +45,9 @@ pub trait Bus
 		T: LeBytes,
 		[(); <T as LeBytes>::SIZE]:;
 
-	fn write<T>(&mut self, address: usize, value: T) -> Result<(), Error>
+	fn write<T, U>(&mut self, address: U, value: T) -> Result<(), Error>
 	where
 		T: LeBytes,
+		U: Into<usize>,
 		[(); <T as LeBytes>::SIZE]:;
 }

--- a/platform/mod.rs
+++ b/platform/mod.rs
@@ -102,11 +102,13 @@ impl Bus for Platform
 		));
 	}
 
-	fn write<T>(&mut self, address: usize, value: T) -> Result<(), bus::Error>
+	fn write<T, U>(&mut self, address: U, value: T) -> Result<(), bus::Error>
 	where
 		T: LeBytes,
+		U: Into<usize>,
 		[(); <T as LeBytes>::SIZE]:,
 	{
+		let address = address.into();
 		let memory = &self.memory;
 		if (memory.start..memory.end).contains(&address) {
 			return self.memory.write(address - MEMORY_BASE, value);
@@ -170,11 +172,13 @@ impl Bus for Memory
 		));
 	}
 
-	fn write<T>(&mut self, address: usize, value: T) -> Result<(), bus::Error>
+	fn write<T, U>(&mut self, address: U, value: T) -> Result<(), bus::Error>
 	where
 		T: LeBytes,
+		U: Into<usize>,
 		[(); <T as LeBytes>::SIZE]:,
 	{
+		let address = address.into();
 		let tmp: [u8; <T as LeBytes>::SIZE] = value.to_le_bytes();
 		self.memory[address..address + <T as LeBytes>::SIZE]
 			.copy_from_slice(&tmp[..<T as LeBytes>::SIZE]);


### PR DESCRIPTION
Having an address parameter that is some U: Into<usize> allows for some more expressive function calls.
Example:
Instead of writing

    uart.write(0, 1);

one could write something like

    uart.write(RegisterAddress::RecieverBuffer, 1);

where `RegisterAddress` is an enum that implements the `Into<usize>` trait.